### PR TITLE
Refactor RK4 integration

### DIFF
--- a/src/main/java/com/particle_life/Physics.java
+++ b/src/main/java/com/particle_life/Physics.java
@@ -16,9 +16,7 @@ public class Physics {
 
     public enum IntegrationMethod {
         EULER,
-        RK4v1,
-        RK4v2,
-        RK4v3
+        RK4
     }
 
     public Particle[] particles;
@@ -127,12 +125,9 @@ public class Physics {
         updateThreadsShouldRun.set(true);
 
         makeContainers();
+		
+		updateVelocity();
 
-        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
-            if (!updateThreadsShouldRun.get()) return false;
-            updateVelocity(i);
-            return true;
-        });
         loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
             updatePosition(i);
@@ -407,8 +402,7 @@ public class Physics {
         }
     }
 
-    private void updateVelocity(int i) {
-        Particle p = particles[i];
+    private void updateVelocity() {
 
         // apply friction before adding new velocity
         double frictionFactor = Math.pow(settings.friction, 60 * settings.dt);  // is normalized to 60 fps
@@ -416,128 +410,71 @@ public class Physics {
 
         switch (integrationMethod) {
             case EULER -> updateVelocityEuler(i);
-            case RK4v1 -> updateVelocityRK4(i);
-            case RK4v2 -> updateVelocityRK4v2(i);
-            case RK4v3 -> updateVelocityRK4v3(i);
+            case RK4 -> updateVelocityRK4(i);
         }
     }
 
     private void updateVelocityEuler(int i) {
-        Particle p = particles[i];
-
-        Vector3d a = accel(i, p.position);
-
-        p.velocity.add(a.mul(settings.dt));
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+            Particle p = particles[i];
+			Vector3d a = accel(i, p.position);
+			p.velocity.add(a.mul(settings.dt));
+            return true;
+        });
     }
-
-    private void updateVelocityRK4(int i) {
-        double dt = settings.dt;
-
-        Particle p = particles[i];
-
-        Vector3d v1 = p.velocity;
-        Vector3d x1 = p.position;
-        Vector3d a1 = accel(i, x1);
-
-        Vector3d v2 = new Vector3d(v1).add(new Vector3d(a1).mul(dt / 2)); // v2 = v + a1 * dt/2
-        Vector3d x2 = new Vector3d(x1).add(new Vector3d(v2).mul(dt / 2)); // x2 = x + v2 * dt/2
-        Vector3d a2 = accel(i, x2);
-
-        Vector3d v3 = new Vector3d(v1).add(new Vector3d(a2).mul(dt / 2)); // v3 = v + a2 * dt/2
-        Vector3d x3 = new Vector3d(x1).add(new Vector3d(v3).mul(dt / 2)); // x3 = x + v3 * dt/2
-        Vector3d a3 = accel(i, x3);
-
-        Vector3d v4 = new Vector3d(v1).add(new Vector3d(a3).mul(dt)); // v4 = v + a3 * dt
-        Vector3d x4 = new Vector3d(x1).add(new Vector3d(v4).mul(dt)); // x4 = x + v4 * dt
-        Vector3d a4 = accel(i, x4);
-
-        // v += (a1 + 2 * a2 + 2 * a3 + a4) * dt/6
-        p.velocity.add(a1
+	
+    private void updateVelocityRK4() {
+		particlesBuffer = particles
+		vector3d[] k1;
+		vector3d[] k2;
+		vector3d[] k3;
+		vector3d[] k4;
+		
+		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+			k1[i] = accel(i, particlesBuffer[i].position)
+            return true;
+        });
+		
+		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+			double dt = settings.dt * 0.5
+			Particle p = particlesBuffer[i]
+			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+			k2[i] = accel(i, p.position)
+            return true;
+        });
+		
+		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+			double dt = settings.dt * 0.5
+			Particle p = particlesBuffer[i]
+			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+			k3[i] = accel(i, p.position)
+            return true;
+        });
+		
+		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+			double dt = settings.dt
+			Particle p = particlesBuffer[i]
+			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+			k4[i] = accel(i, p.position)
+            return true;
+        });
+		
+		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+			Particle p = particles[i]
+			p.velocity.add(a1
                 .add(a2.mul(2))
                 .add(a3.mul(2))
                 .add(a4)
                 .mul(dt / 6));
-    }
-
-    private void updateVelocityRK4v2(int i) {
-        double dt = settings.dt;
-
-        Particle p = particles[i];
-
-        Vector3d v1 = p.velocity;
-        Vector3d x1 = p.position;
-        Vector3d a1 = accel(i, x1);
-
-
-        // v2 = v + a1 * dt/2
-        Vector3d v2 = new Vector3d(v1)
-                .add(new Vector3d(a1).mul(dt / 2));
-        // x2 = x + v2 * dt/2 + 0.5 * a1 * (dt/2)^2
-        Vector3d x2 = new Vector3d(x1)
-                .add(new Vector3d(v2).mul(dt / 2))
-                .add(new Vector3d(a1).mul(dt * dt / 8));
-        Vector3d a2 = accel(i, x2);
-
-        // v3 = v + a2 * dt/2
-        Vector3d v3 = new Vector3d(v1)
-                .add(new Vector3d(a2).mul(dt / 2));
-        // x3 = x + v3 * dt/2 + 0.5 * a2 * (dt/2)^2
-        Vector3d x3 = new Vector3d(x1)
-                .add(new Vector3d(v3).mul(dt / 2))
-                .add(new Vector3d(a2).mul(dt * dt / 8));
-        Vector3d a3 = accel(i, x3);
-
-        // v4 = v + a3 * dt
-        Vector3d v4 = new Vector3d(v1)
-                .add(new Vector3d(a3).mul(dt));
-        // x4 = x + v4 * dt + 0.5 * a3 * dt^2/2
-        Vector3d x4 = new Vector3d(x1)
-                .add(new Vector3d(v4).mul(dt))
-                .add(new Vector3d(a3).mul(dt * dt / 2));
-        Vector3d a4 = accel(i, x4);
-
-        // v += (a1 + 2 * a2 + 2 * a3 + a4) * dt/6
-        p.velocity.add(a1
-                .add(a2.mul(2))
-                .add(a3.mul(2))
-                .add(a4)
-                .mul(dt / 6));
-    }
-    private void updateVelocityRK4v3(int i) {
-        double dt = settings.dt;
-
-        Particle p = particles[i];
-
-        Vector3d x1 = p.position;
-        Vector3d a1 = accel(i, x1);
-
-        Vector3d v1 = p.velocity;
-        Vector3d x2 = new Vector3d(x1)
-                .add(new Vector3d(v1).mul(dt / 2))
-                .add(new Vector3d(a1).mul(dt * dt / 8));
-        Vector3d a2 = accel(i, x2);
-
-        Vector3d v2 = new Vector3d(v1)
-                .add(new Vector3d(a2).mul(dt / 2));
-        Vector3d x3 = new Vector3d(x1)
-                .add(new Vector3d(v2).mul(dt / 2))
-                .add(new Vector3d(a2).mul(dt * dt / 8));
-        Vector3d a3 = accel(i, x3);
-
-        Vector3d v3 = new Vector3d(v1)
-                .add(new Vector3d(a3).mul(dt));
-        Vector3d x4 = new Vector3d(x1)
-                .add(new Vector3d(v3).mul(dt))
-                .add(new Vector3d(a3).mul(dt * dt / 2));
-        Vector3d a4 = accel(i, x4);
-
-        // v += (a1 + 2 * a2 + 2 * a3 + a4) * dt/6
-        p.velocity.add(a1
-                .add(a2.mul(2))
-                .add(a3.mul(2))
-                .add(a4)
-                .mul(dt / 6));
-    }
+            return true;
+        });
+		
 
     private Vector3d accel(int i, Vector3d position) {
         Particle p = particles[i];
@@ -584,12 +521,14 @@ public class Physics {
     }
 
     private void updatePosition(int i) {
-        Particle p = particles[i];
-
-        // pos += vel * dt
-        p.velocity.mulAdd(settings.dt, p.position, p.position);
-
-        ensurePosition(p.position);
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+            if (!updateThreadsShouldRun.get()) return false;
+            Particle p = particles[i];
+			// pos += vel * dt
+			p.velocity.mulAdd(settings.dt, p.position, p.position);
+			ensurePosition(p.position);
+            return true;
+        });
     }
 
     /**

--- a/src/main/java/com/particle_life/Physics.java
+++ b/src/main/java/com/particle_life/Physics.java
@@ -425,56 +425,60 @@ public class Physics {
     }
 	
     private void updateVelocityRK4() {
-		particlesBuffer = particles
-		vector3d[] k1;
-		vector3d[] k2;
-		vector3d[] k3;
-		vector3d[] k4;
-		
-		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+        particlesBuffer = particles
+        vector3d[] k1;
+        vector3d[] k2;
+        vector3d[] k3;
+        vector3d[] k4;
+
+        // Maybe do getContainers() here?
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
-			k1[i] = accel(i, particlesBuffer[i].position)
+            k1[i] = accel(i, particlesBuffer[i].position)
             return true;
         });
-		
-		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+        
+        // Maybe do getContainers() here?
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
-			double dt = settings.dt * 0.5
-			Particle p = particlesBuffer[i]
-			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
-			k2[i] = accel(i, p.position)
+            double dt = settings.dt * 0.5
+            Particle p = particlesBuffer[i]
+            p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+            k2[i] = accel(i, p.position)
             return true;
         });
-		
-		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+        
+        // Maybe do getContainers() here?
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
-			double dt = settings.dt * 0.5
-			Particle p = particlesBuffer[i]
-			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
-			k3[i] = accel(i, p.position)
+            double dt = settings.dt * 0.5
+            Particle p = particlesBuffer[i]
+            p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+            k3[i] = accel(i, p.position)
             return true;
         });
-		
-		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+        
+        // Maybe do getContainers() here?
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
-			double dt = settings.dt
-			Particle p = particlesBuffer[i]
-			p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
-			k4[i] = accel(i, p.position)
+            double dt = settings.dt
+            Particle p = particlesBuffer[i]
+            p.position = p.position.add(p.velocity.mul(dt)).add(k3[i].mul(0.5).mul(dt*dt))
+            k4[i] = accel(i, p.position)
             return true;
         });
-		
-		loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
+        
+        loadDistributor.distributeLoadEvenly(particles.length, preferredNumberOfThreads, i -> {
             if (!updateThreadsShouldRun.get()) return false;
-			Particle p = particles[i]
-			p.velocity.add(a1
+            double dt = settings.dt
+            Particle p = particles[i]
+            p.velocity.add(a1
                 .add(a2.mul(2))
                 .add(a3.mul(2))
                 .add(a4)
                 .mul(dt / 6));
             return true;
         });
-		
 
     private Vector3d accel(int i, Vector3d position) {
         Particle p = particles[i];


### PR DESCRIPTION
The nature of RK4 integration requires a bit of a rethink into how the particle updates are parallelized. I've refactored both the Euler and RK4 `updateVelocity` functions to place the parallelization inside the scope of the functions themselves. Assuming I've done this correctly, this should now be able to correctly implement RK4, as well as providing additional flexibility if/when you decide to try more integrators.

I spent a few days trying to setup an environment for developing Java, but I couldn't figure out how to get the app to import from my local code. As such, **this code is completely untested!** I realize that this is a terrible practice, and I apologize for the fact that I'm essentially asking you to debug my code. Having said that, I think I understand at least the organization of your code well enough to provide a decent starting point. A few points to be aware of:

1. I'm targeting the PR at your runge-kutta branch, so at the very least, it won't ruin everything. 
2. I saw that there was a `particlesBuffer` attribute of the `Physics` class which didn't seem to get used anywhere, so I used it to hold onto the temporary steps involved in RK4. If that was actually something important, you should be able to just create another array of particles as a public attribute.
3. There are 5 calls (not 4) to `loadDistributor.distributeLoadEvenly` within `updateVelocityRK4`. The first 4 calculate the k-values, and the 5th applies them.
4. Each substep in the RK4 process is done using the initial containers. Essentially this bakes in the assumption that rmax is much larger than the distance the particle moves in one step. If this assumption breaks down, I expect it would cause problems. Depending on the computational load of `getContainers()`, it might make sense to call that before calculating each k-coefficient.